### PR TITLE
Added working github actions workflow to deploy to github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,9 +29,12 @@ jobs:
         run: CI=false npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: "github-pages"
           path: ./build
+          if-no-files-found: error
 
   deploy:
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - main
 
-jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
+jobs:
+  build:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -18,22 +22,24 @@ jobs:
         with:
           node-version: "18"
 
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.OS }}-node-
-
       - name: Install dependencies
         run: npm install
 
       - name: Build
         run: CI=false npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          branch: gh-pages
-          folder: build
+          path: ./build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Setup Github Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
@@ -29,8 +33,7 @@ jobs:
         run: CI=false npm run build
 
       - name: Upload artifact
-        id: upload-artifact
-        uses: actions/upload-pages-artifact@main
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Build and Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build
+
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@4.1.5
+      with:
+        branch: gh-pages
+        folder: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,11 +30,9 @@ jobs:
 
       - name: Upload artifact
         id: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@main
         with:
-          name: "github-pages"
           path: ./build
-          if-no-files-found: error
 
   deploy:
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm install
 
       - name: Build
-        run: npm run build
+        run: CI=false npm run build
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,22 +10,30 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: '14'
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
 
-    - name: Build
-      run: npm run build
+      - name: Install dependencies
+        run: npm install
 
-    - name: Deploy to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@4.1.5
-      with:
-        branch: gh-pages
-        folder: build
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: build

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "data_nexus",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://beveradb.github.io/DataNexus",
+  "homepage": "https://datanexus.one",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "data_nexus",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://datanexus.one",
+  "homepage": "https://beveradb.github.io/DataNexus",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "data_nexus",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://beveradb.github.io/DataNexus",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
@@ -24,8 +23,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "predeploy": "npm run build"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "data_nexus",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://beveradb.github.io/DataNexus",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import NavBar from './Components/NavBar/NavBar';
 import HomePage from './Pages/HomePage/HomePage';
 import Error from './Pages/Error/Error';
@@ -12,7 +12,7 @@ function App() {
 
     return (
         <div className="App">
-            <Router>
+            <HashRouter>
                 <NavBar />
                 <Routes>
                     <Route path='/' element={<HomePage setResultData={setResultData} />} />
@@ -20,7 +20,7 @@ function App() {
                     <Route path='/lot' element={<LotData />} />
                     <Route path='*' element={<Error />} />
                 </Routes>
-            </Router>
+            </HashRouter>
         </div>
     );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ function App() {
 
     return (
         <div className="App">
-            <HashRouter>
+            <Router>
                 <NavBar />
                 <Routes>
                     <Route path='/' element={<HomePage setResultData={setResultData} />} />
@@ -20,7 +20,7 @@ function App() {
                     <Route path='/lot' element={<LotData />} />
                     <Route path='*' element={<Error />} />
                 </Routes>
-            </HashRouter>
+            </Router>
         </div>
     );
 }


### PR DESCRIPTION
This PR replaces the old method of deploying by manually running `npm run deploy` locally.

Now, all you should need to do is push your commits on the `main` branch and the workflow will automatically run, it will build your app and deploy it to your Github Pages instance.

(all you should need to do is merge this PR and it should "just work" - then I'd recommend doing `git pull` locally after merging to make sure you're in sync locally too)

I also changed the app routing to use HashRouter, as that allows deployment in subfolders (this was easier for me when testing on my own github pages subdomain) - but that's not mandatory so if having the hash in the URL annoys you, it can easily be reverted to BrowserRouter 😄 